### PR TITLE
fix:issue#1 keep java method uppercase same with ProtoBuffer rpc method

### DIFF
--- a/java-protobuf-plugin/src/java_plugin/cpp/JavaPrxCallbackGenerator.cpp
+++ b/java-protobuf-plugin/src/java_plugin/cpp/JavaPrxCallbackGenerator.cpp
@@ -204,7 +204,7 @@ namespace JavaTarsPrxCbGenerator
                                                         method->input_type());
             (*vars)["output_type"] = MessageFullJavaName(generate_nano,
                                                          method->output_type());
-            (*vars)["lower_method_name"] = LowerMethodName(method);
+            (*vars)["lower_method_name"] = method->name();
             (*vars)["method_field_name"] = MethodPropertiesFieldName(method);
             bool client_streaming = method->client_streaming();
             bool server_streaming = method->server_streaming();

--- a/java-protobuf-plugin/src/java_plugin/cpp/JavaPrxGenerator.cpp
+++ b/java-protobuf-plugin/src/java_plugin/cpp/JavaPrxGenerator.cpp
@@ -237,8 +237,16 @@ namespace JavaTarsPrxGenerator
                                 "$output_type$ $lower_method_name$($input_type$ request)");
                         p->Print(";\n");
                         p->Print(
+                        		*vars,
+                                "$output_type$ $lower_method_name$($input_type$ request, @TarsContext java.util.Map<String, String> ctx)");
+                        p->Print(";\n");
+                        p->Print(
                                 *vars,
                                 "void async_$lower_method_name$(@TarsCallback $service_name$PrxCallback callback, $input_type$ request)");
+                        p->Print(";\n");
+                        p->Print(
+                                *vars,
+                                "void async_$lower_method_name$(@TarsCallback $service_name$PrxCallback callback, $input_type$ request, @TarsContext java.util.Map<String, String> ctx)");
                     }
                     break;
                 case ASYNC_CALL:
@@ -283,7 +291,8 @@ namespace JavaTarsPrxGenerator
         p->Print("import com.qq.tars.protocol.tars.annotation.TarsCallback;\n"
                          "import com.qq.tars.rpc.protocol.proto.ProtoCodec;\n"
                          "import com.qq.tars.protocol.annotation.Servant;\n"
-                         "import com.qq.tars.protocol.annotation.ServantCodec;\n\n");
+                         "import com.qq.tars.protocol.annotation.ServantCodec;\n"
+                         "import com.qq.tars.protocol.annotation.TarsContext;\n\n");
         if (generateNano)
         {
             p->Print("import java.io.IOException;\n\n");

--- a/java-protobuf-plugin/src/java_plugin/cpp/JavaPrxGenerator.cpp
+++ b/java-protobuf-plugin/src/java_plugin/cpp/JavaPrxGenerator.cpp
@@ -200,7 +200,7 @@ namespace JavaTarsPrxGenerator
             const MethodDescriptor *method = service->method(i);
             (*vars)["input_type"] = MessageFullJavaName(generate_nano, method->input_type());
             (*vars)["output_type"] = MessageFullJavaName(generate_nano, method->output_type());
-            (*vars)["lower_method_name"] = LowerMethodName(method);
+            (*vars)["lower_method_name"] = method->name();
             (*vars)["method_field_name"] = MethodPropertiesFieldName(method);
             bool client_streaming = method->client_streaming();
             bool server_streaming = method->server_streaming();

--- a/java-protobuf-plugin/src/java_plugin/cpp/JavaServantGenerator.cpp
+++ b/java-protobuf-plugin/src/java_plugin/cpp/JavaServantGenerator.cpp
@@ -192,7 +192,7 @@ namespace JavaTarsServantGenerator
                                                         method->input_type());
             (*vars)["output_type"] = MessageFullJavaName(generate_nano,
                                                          method->output_type());
-            (*vars)["lower_method_name"] = LowerMethodName(method);
+            (*vars)["lower_method_name"] = method->name();
             (*vars)["method_field_name"] = MethodPropertiesFieldName(method);
             bool client_streaming = method->client_streaming();
             bool server_streaming = method->server_streaming();


### PR DESCRIPTION
Closes #1  
keep generated java method uppercase same with ProtoBuffer rpc method when it started with uppercase.

Closes #3 
add context parameter method